### PR TITLE
Improved error handling for consumer streams

### DIFF
--- a/lib/weddell/client/subscriber/stream.ex
+++ b/lib/weddell/client/subscriber/stream.ex
@@ -135,13 +135,14 @@ defmodule Weddell.Client.Subscriber.Stream do
     case GRPCStub.recv(stream.grpc_stream) do
       {:ok, recv} ->
         recv
-        |> Stream.map(fn reply ->
-          case reply do
-            {:ok, response} -> Enum.map(response.received_messages, &Message.new/1)
-            {:error, _} -> []
-          end
+        |> Stream.map(fn
+          {:ok, response} ->
+            {:ok, Enum.map(response.received_messages, &Message.new/1)}
+          {:error, _} = error ->
+            error
         end)
-      {:error, _} -> []
+      {:error, _} = error ->
+        error
     end
   end
 end

--- a/lib/weddell/client/subscriber/stream.ex
+++ b/lib/weddell/client/subscriber/stream.ex
@@ -3,6 +3,7 @@ defmodule Weddell.Client.Subscriber.Stream do
   A streaming connection to a subscription.
   """
   alias GRPC.Client.Stream, as: GRPCStream
+  alias GRPC.RPCError
   alias GRPC.Stub, as: GRPCStub
   alias Google.Pubsub.V1.{Subscriber.Stub,
                           StreamingPullRequest}
@@ -17,6 +18,7 @@ defmodule Weddell.Client.Subscriber.Stream do
   defstruct [:client, :subscription, :grpc_stream]
 
   @default_ack_deadline 10
+  @deadline_expired 4
 
   @doc """
   Open a new stream on a subscription.
@@ -137,12 +139,15 @@ defmodule Weddell.Client.Subscriber.Stream do
         recv
         |> Stream.map(fn
           {:ok, response} ->
-            {:ok, Enum.map(response.received_messages, &Message.new/1)}
-          {:error, _} = error ->
-            error
+            Enum.map(response.received_messages, &Message.new/1)
+          {:error, %RPCError{status: @deadline_expired}} ->
+            # Deadline expired and stream ended, this is expected
+            []
+          {:error, e} ->
+            raise e
         end)
-      {:error, _} = error ->
-        error
+      {:error, e} ->
+        raise e
     end
   end
 end

--- a/lib/weddell/consumer.ex
+++ b/lib/weddell/consumer.ex
@@ -1,4 +1,6 @@
 defmodule Weddell.Consumer do
+  alias GRPC.RPCError
+
   alias Weddell.{Message,
                  Client.Subscriber}
 
@@ -16,6 +18,8 @@ defmodule Weddell.Consumer do
     quote do
       require Logger
       @behaviour Weddell.Consumer
+
+      @deadline_expired 4
 
       def child_spec(subscription) do
         %{
@@ -42,9 +46,22 @@ defmodule Weddell.Consumer do
 
         stream
         |> Subscriber.Stream.recv()
-        |> Enum.each(fn messages ->
-             dispatch(messages, stream)
-           end)
+        |> case do
+          {:error, e} = error ->
+            Logger.error(e)
+            error
+          batches ->
+            Enum.each(batches, fn
+              {:ok, messages} ->
+                dispatch(messages, stream)
+              {:error, %RPCError{status: @deadline_expired} = error} ->
+                # Deadline expired and stream ended, this is expected
+                []
+              {:error, e} = error ->
+                Logger.error(e)
+                error
+            end)
+        end
 
         GenServer.cast self(), :listen
 


### PR DESCRIPTION
* Streams expire after a deadline passes, ignore and retry
* Other RPCErrors are logged