### PR TITLE
Infinite timeout

### DIFF
--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -125,15 +125,18 @@ defmodule Weddell.Client do
     host = Keyword.get(opts, :host, @default_host)
     port = Keyword.get(opts, :port, @default_port)
     {:ok, channel} =
-      Stub.connect("#{host}:#{port}", cred: cred)
+      Stub.connect("#{host}:#{port}", cred: cred, adapter_opts: %{
+        http2_opts: %{keepalive: :infinity}
+      })
     {:ok, %__MODULE__{channel: channel,
                       project: project}}
   end
 
   @doc false
   @spec request_opts() :: Keyword.t
-  def request_opts() do
+  def request_opts(extra_opts \\ []) do
     [metadata: auth_header(), content_type: "application/grpc"]
+    |> Enum.concat(extra_opts)
   end
 
   @doc false

--- a/lib/weddell/client/subscriber/stream.ex
+++ b/lib/weddell/client/subscriber/stream.ex
@@ -3,6 +3,7 @@ defmodule Weddell.Client.Subscriber.Stream do
   A streaming connection to a subscription.
   """
   alias GRPC.Client.Stream, as: GRPCStream
+  alias GRPC.RPCError
   alias GRPC.Stub, as: GRPCStub
   alias Google.Pubsub.V1.{Subscriber.Stub,
                           StreamingPullRequest}
@@ -17,6 +18,7 @@ defmodule Weddell.Client.Subscriber.Stream do
   defstruct [:client, :subscription, :grpc_stream]
 
   @default_ack_deadline 10
+  @unavailable 14
 
   @doc """
   Open a new stream on a subscription.
@@ -138,6 +140,8 @@ defmodule Weddell.Client.Subscriber.Stream do
         |> Stream.map(fn
           {:ok, response} ->
             Enum.map(response.received_messages, &Message.new/1)
+          {:error, %RPCError{status: @unavailable}} ->
+            []
           {:error, e} ->
             raise e
         end)

--- a/lib/weddell/client/subscriber/stream.ex
+++ b/lib/weddell/client/subscriber/stream.ex
@@ -3,7 +3,6 @@ defmodule Weddell.Client.Subscriber.Stream do
   A streaming connection to a subscription.
   """
   alias GRPC.Client.Stream, as: GRPCStream
-  alias GRPC.RPCError
   alias GRPC.Stub, as: GRPCStub
   alias Google.Pubsub.V1.{Subscriber.Stub,
                           StreamingPullRequest}
@@ -18,7 +17,6 @@ defmodule Weddell.Client.Subscriber.Stream do
   defstruct [:client, :subscription, :grpc_stream]
 
   @default_ack_deadline 10
-  @deadline_expired 4
 
   @doc """
   Open a new stream on a subscription.
@@ -37,7 +35,7 @@ defmodule Weddell.Client.Subscriber.Stream do
     stream =
       %__MODULE__{client: client,
                   subscription: subscription,
-                  grpc_stream: Stub.streaming_pull(client.channel, Client.request_opts())}
+                  grpc_stream: Stub.streaming_pull(client.channel, Client.request_opts(timeout: :infinity))}
     request =
       StreamingPullRequest.new(subscription: Util.full_subscription(client.project, subscription),
                                stream_ack_deadline_seconds: @default_ack_deadline)
@@ -134,15 +132,12 @@ defmodule Weddell.Client.Subscriber.Stream do
   """
   @spec recv(stream :: t) :: Enumerable.t
   def recv(stream) do
-    case GRPCStub.recv(stream.grpc_stream) do
+    case GRPCStub.recv(stream.grpc_stream, timeout: :infinity) do
       {:ok, recv} ->
         recv
         |> Stream.map(fn
           {:ok, response} ->
             Enum.map(response.received_messages, &Message.new/1)
-          {:error, %RPCError{status: @deadline_expired}} ->
-            # Deadline expired and stream ended, this is expected
-            []
           {:error, e} ->
             raise e
         end)


### PR DESCRIPTION
I got lots of error on my server

```
terminating {:stop, {:goaway, 2147483647, :no_error, "max_age"}, :"Client is going away."} Last message: {:"$gen_cast", :listen}
```

and found this thread https://github.com/tony612/grpc-elixir/issues/56

Solution presented is to change the `timeout` for both client and the RPC call to `:infinity`, this PR does exactly that, by doing this, it'll handle `deadline_expired` and `goaway` properly

This PR will also handle https://github.com/tony612/grpc-elixir/blob/a4915d8c0a840477239bf18a2a725888490b5e4a/lib/grpc/status.ex#L115, and the proper way to handle it is by retrying