### PR TITLE
Local dev and emulator hack

### DIFF
--- a/lib/weddell.ex
+++ b/lib/weddell.ex
@@ -249,7 +249,7 @@ defmodule Weddell do
       Weddell.acknowledge(messages, "foo-subscription")
       #=> :ok
   """
-  @spec acknowledge(messages :: [Message.t] | message :: Message.t,
+  @spec acknowledge(messages :: [Message.t] |  Message.t,
                     subscription_name :: String.t) :: :ok | error
   def acknowledge(messages, subscription) do
     GenServer.call(Weddell.Client, {:acknowledge, messages, subscription})

--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -173,7 +173,7 @@ defmodule Weddell.Client do
   end
 
   defp auth_header do
-    if Code.ensure_compiled?(Goth.Token) do
+    if Code.ensure_compiled?(Goth.Token) and not Application.get_env(:goth, :disabled, false) do
       case Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub") do
         {:ok, %{token: token, type: token_type}} ->
           %{"authorization" => "#{token_type} #{token}"}

--- a/lib/weddell/client/publisher.ex
+++ b/lib/weddell/client/publisher.ex
@@ -18,8 +18,8 @@ defmodule Weddell.Client.Publisher do
   @default_list_max 50
 
   @typedoc "A new Pub/Sub message -- can contain data, attributes, or both"
-  @type new_message :: data :: binary |
-                       attributes :: map |
+  @type new_message :: (data :: binary) |
+                       (attributes :: map) |
                        {data :: binary, attributes :: map}
 
   defp stub_module do


### PR DESCRIPTION
In addition to some formatting this fork ensures the "Bad GCP Credentials" error message does not occur when running with the local emulator. With one of our GenServer's recursive calls we were seeing infinite "Bad GCP Credentials" messages.