### PR TITLE
Allow to use fully qualified names in subscriptions and topics.

### DIFF
--- a/lib/weddell/client/publisher.ex
+++ b/lib/weddell/client/publisher.ex
@@ -55,7 +55,7 @@ defmodule Weddell.Client.Publisher do
   def topics(client, opts \\ []) do
     max_topics = Keyword.get(opts, :max, @default_list_max)
     cursor = Keyword.get(opts, :cursor, "")
-    request = ListTopicsRequest.new(project: "projects/#{client.project}",
+    request = ListTopicsRequest.new(project: Util.full_project(client.project),
                                     page_size: max_topics,
                                     page_token: cursor)
     client.channel

--- a/lib/weddell/client/subscriber.ex
+++ b/lib/weddell/client/subscriber.ex
@@ -64,7 +64,7 @@ defmodule Weddell.Client.Subscriber do
   def subscriptions(client, opts \\ []) do
     max_topics = Keyword.get(opts, :max, @default_list_max)
     cursor = Keyword.get(opts, :cursor, "")
-    request = ListSubscriptionsRequest.new(project: "projects/#{client.project}",
+    request = ListSubscriptionsRequest.new(project: Util.full_project(client.project),
                                     page_size: max_topics,
                                     page_token: cursor)
     client.channel

--- a/lib/weddell/client/util.ex
+++ b/lib/weddell/client/util.ex
@@ -1,13 +1,36 @@
 defmodule Weddell.Client.Util do
   @moduledoc false
 
+  @subscription_regex ~r/projects\/.+\/subscriptions\/.+/
+  @topics_regex ~r/projects\/.+\/topics\/.+/
+
   @spec full_subscription(project :: String.t, subscription :: String.t) :: String.t
+  def full_subscription(project, "projects/" <> _ = name) do
+    case Regex.match?(@subscription_regex, name) do
+      true  -> name
+      false -> make_full_subscription(project, name)
+    end
+  end
   def full_subscription(project, name) do
+    make_full_subscription(project, name)
+  end
+
+  defp make_full_subscription(project, name) do
     "#{full_project(project)}/subscriptions/#{name}"
   end
 
   @spec full_topic(project :: String.t, topic :: String.t) :: String.t
+  def full_topic(project, "projects/" <> _ = name) do
+    case Regex.match?(@topics_regex, name) do
+      true  -> name
+      false -> make_full_topic(project, name)
+    end
+  end
   def full_topic(project, name) do
+    make_full_topic(project, name)
+  end
+
+  defp make_full_topic(project, name) do
     "#{full_project(project)}/topics/#{name}"
   end
 

--- a/test/weddell/client/util_test.exs
+++ b/test/weddell/client/util_test.exs
@@ -12,12 +12,44 @@ defmodule Weddell.Client.UtilTest do
       assert Util.full_subscription(@project, @subscription) ==
         "projects/#{@project}/subscriptions/#{@subscription}"
     end
+    test "returns original string if it's a fully qualified subscription" do
+      full_subscription = "projects/myproject/subscriptions/mysubscription"
+      assert Util.full_subscription(@project, full_subscription) == full_subscription
+    end
+    test "builds a full subscription if not fully qualified" do
+      subscriptions = [
+        "projects/myproject/subscription/mysubscription", # without s in subscriptions
+        "projects/myproject/subscriptionsmysubscription", # missing slash
+        "projects//subscriptions/mysubscription", # missing project
+        "projects/myproject/subscriptions/", # missing subscription name
+        "projects/myproject/something" # missing subscriptions bit
+      ]
+      Enum.each(subscriptions, fn(sub) ->
+        assert Util.full_subscription(@project, sub) == "projects/#{@project}/subscriptions/#{sub}"
+      end)
+    end
   end
 
   describe "Util.full_topic\2" do
     test "builds a full topic string" do
       assert Util.full_topic(@project, @topic) ==
         "projects/#{@project}/topics/#{@topic}"
+    end
+    test "returns original string if it's a fully qualified topic" do
+      full_topic = "projects/myproject/topics/mytopic"
+      assert Util.full_topic(@project, full_topic) == full_topic
+    end
+    test "builds a full topic if not fully qualified" do
+      topics = [
+        "projects/myproject/topic/mytopic", # without s in topics
+        "projects/myproject/topicsmytopic", # missing slash
+        "projects//topics/mytopic", # missing project
+        "projects/myproject/topics/", # missing topic name
+        "projects/myproject/something" # missing topics bit
+      ]
+      Enum.each(topics, fn(topic) ->
+        assert Util.full_topic(@project, topic) == "projects/#{@project}/topics/#{topic}"
+      end)
     end
   end
 


### PR DESCRIPTION
If a topic is specified as "projects/myproject/topics/mytopic"
leave the string as is without adding a project to it.
Same for topics.

This should make it possible to publish/receive messages from different
projects when permitted by pubsub.