### PR TITLE
Allow standalone client

### DIFF
--- a/lib/weddell.ex
+++ b/lib/weddell.ex
@@ -18,7 +18,10 @@ defmodule Weddell do
   """
   def start(_type, _args) do
     import Supervisor.Spec
-    children = [worker(Client, [])]
+    children = case Application.get_env(:weddell, :no_connect_on_start, false) do
+      true -> []
+      false -> [worker(Client, [])]
+    end
     opts = [strategy: :one_for_one, name: __MODULE__]
     Supervisor.start_link(children, opts)
   end

--- a/lib/weddell.ex
+++ b/lib/weddell.ex
@@ -31,7 +31,7 @@ defmodule Weddell do
   """
   @spec client(timeout :: integer()) :: Client.t
   def client(timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:client}, timeout)
+    Weddell.Client.client(Weddell.Client, timeout)
   end
 
   @doc """
@@ -43,7 +43,7 @@ defmodule Weddell do
   """
   @spec create_topic(topic_name :: String.t, timeout :: integer()) :: :ok | error
   def create_topic(name, timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:create_topic, name}, timeout)
+    Weddell.Client.create_topic(Weddell.Client, name, timeout)
   end
 
   @doc """
@@ -55,7 +55,7 @@ defmodule Weddell do
   """
   @spec delete_topic(topic_name :: String.t, timeout :: integer()) :: :ok | error
   def delete_topic(name, timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:delete_topic, name}, timeout)
+    Weddell.Client.delete_topic(Weddell.Client, name, timeout)
   end
 
   @doc """
@@ -84,7 +84,7 @@ defmodule Weddell do
     {:ok, topic_names :: [String.t], Client.cursor} |
     error
   def topics(opts \\ [], timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:topics, opts}, timeout)
+    Weddell.Client.topics(Weddell.Client, opts, timeout)
   end
 
   @doc """
@@ -113,7 +113,7 @@ defmodule Weddell do
                             timeout :: integer()) ::
     :ok | error
   def create_subscription(name, topic, opts \\ [], timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:create_subscription, name, topic, opts}, timeout)
+    Weddell.Client.create_subscription(Weddell.Client, name, topic, opts, timeout)
   end
 
   @doc """
@@ -126,7 +126,7 @@ defmodule Weddell do
   @spec delete_subscription(subscription_name :: String.t, timeout :: integer()) ::
     :ok | error
   def delete_subscription(name, timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:delete_subscription, name}, timeout)
+    Weddell.Client.delete_subscription(Weddell.Client, name, timeout)
   end
 
   @doc """
@@ -155,7 +155,7 @@ defmodule Weddell do
     {:ok, subscriptions :: [SubscriptionDetails.t], Client.cursor} |
     error
   def subscriptions(opts \\ [], timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:subscriptions, opts}, timeout)
+    Weddell.Client.subscriptions(Weddell.Client, opts, timeout)
   end
 
   @doc """
@@ -186,7 +186,7 @@ defmodule Weddell do
     {:ok, subscriptions :: [String.t], Client.cursor} |
     error
   def topic_subscriptions(topic, opts \\ [], timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:topic_subscriptions, topic, opts}, timeout)
+    Weddell.Client.topic_subscriptions(Weddell.Client, topic, opts, timeout)
   end
 
   @doc """
@@ -224,7 +224,7 @@ defmodule Weddell do
                 timeout :: integer()) ::
     :ok | error
   def publish(messages, topic, timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:publish, messages, topic}, timeout)
+    Weddell.Client.publish(Weddell.Client, messages, topic, timeout)
   end
 
   @doc """
@@ -248,7 +248,7 @@ defmodule Weddell do
              timeout :: integer()) ::
     {:ok, messages :: [Message.t]} | error
   def pull(subscription, opts \\ [], timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:pull, subscription, opts}, timeout)
+    Weddell.Client.pull(Weddell.Client, subscription, opts, timeout)
   end
 
   @doc """
@@ -265,6 +265,6 @@ defmodule Weddell do
                     timeout :: integer()) ::
     :ok | error
   def acknowledge(messages, subscription, timeout \\ 5000) do
-    GenServer.call(Weddell.Client, {:acknowledge, messages, subscription}, timeout)
+    Weddell.Client.acknowledge(Weddell.Client, messages, subscriptions, timeout)
   end
 end

--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -87,12 +87,17 @@ defmodule Weddell.Client do
       _(default: [:cacerts: :certifi.cacerts()])_
   """
   def start_link do
-    GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
+    project = Application.get_env(:weddell, :project)
+    options = Application.get_all_env(:weddell)
+    start_link(project, options, name: __MODULE__)
   end
 
-  def init(:ok) do
-    connect(Application.get_env(:weddell, :project),
-            Application.get_all_env(:weddell))
+  def start_link(project, options, gen_server_options \\ []) do
+    GenServer.start_link(__MODULE__, [project, options], gen_server_options)
+  end
+
+  def init([project, options]) do
+    connect(project, options)
   end
 
   @doc """

--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -96,6 +96,94 @@ defmodule Weddell.Client do
     GenServer.start_link(__MODULE__, [project, options], gen_server_options)
   end
 
+  @spec client(server :: GenServer.server(), timeout :: integer()) :: Client.t
+  def client(server, timeout \\ 5000) do
+    GenServer.call(server, {:client}, timeout)
+  end
+
+  @spec create_topic(server :: GenServer.server(), topic_name :: String.t, timeout :: integer()) :: :ok | error
+  def create_topic(server, name, timeout \\ 5000) do
+    GenServer.call(server, {:create_topic, name}, timeout)
+  end
+
+  @spec delete_topic(server :: GenServer.server(), topic_name :: String.t, timeout :: integer()) :: :ok | error
+  def delete_topic(server, name, timeout \\ 5000) do
+    GenServer.call(server, {:delete_topic, name}, timeout)
+  end
+
+  @spec topics(server :: GenServer.server(), opts :: Client.list_options, timeout :: integer()) ::
+    {:ok, topic_names :: [String.t]} |
+    {:ok, topic_names :: [String.t], Client.cursor} |
+    error
+  def topics(server, opts \\ [], timeout \\ 5000) do
+    GenServer.call(server, {:topics, opts}, timeout)
+  end
+
+  @spec create_subscription(server :: GenServer.server(),
+                            subscription_name :: String.t,
+                            topic_name :: String.t,
+                            Client.subscription_options,
+                            timeout :: integer()) ::
+    :ok | error
+  def create_subscription(server, name, topic, opts \\ [], timeout \\ 5000) do
+    GenServer.call(server, {:create_subscription, name, topic, opts}, timeout)
+  end
+
+  @spec delete_subscription(server :: GenServer.server(),
+                            subscription_name :: String.t,
+                            timeout :: integer()) ::
+    :ok | error
+  def delete_subscription(server, name, timeout \\ 5000) do
+    GenServer.call(server, {:delete_subscription, name}, timeout)
+  end
+
+  @spec subscriptions(server :: GenServer.server(),
+                      opts :: Client.list_options,
+                      timeout :: integer()) ::
+    {:ok, subscriptions :: [SubscriptionDetails.t]} |
+    {:ok, subscriptions :: [SubscriptionDetails.t], Client.cursor} |
+    error
+  def subscriptions(server, opts \\ [], timeout \\ 5000) do
+    GenServer.call(server, {:subscriptions, opts}, timeout)
+  end
+
+  @spec topic_subscriptions(server :: GenServer.server(),
+                            topic :: String.t,
+                            opts :: Client.list_options,
+                            timeout :: integer()) ::
+    {:ok, subscriptions :: [String.t]} |
+    {:ok, subscriptions :: [String.t], Client.cursor} |
+    error
+  def topic_subscriptions(server, topic, opts \\ [], timeout \\ 5000) do
+    GenServer.call(server, {:topic_subscriptions, topic, opts}, timeout)
+  end
+
+  @spec publish(server :: GenServer.server(),
+                Publisher.new_message | [Publisher.new_message],
+                topic_name :: String.t,
+                timeout :: integer()) ::
+    :ok | error
+  def publish(server, messages, topic, timeout \\ 5000) do
+    GenServer.call(server, {:publish, messages, topic}, timeout)
+  end
+
+  @spec pull(server :: GenServer.server(),
+             subscription_name :: String.t, Client.pull_options,
+             timeout :: integer()) ::
+    {:ok, messages :: [Message.t]} | error
+  def pull(server, subscription, opts \\ [], timeout \\ 5000) do
+    GenServer.call(server, {:pull, subscription, opts}, timeout)
+  end
+
+  @spec acknowledge(server :: GenServer.server(),
+                    messages :: [Message.t] |  Message.t,
+                    subscription_name :: String.t,
+                    timeout :: integer()) ::
+    :ok | error
+  def acknowledge(server, messages, subscription, timeout \\ 5000) do
+    GenServer.call(server, {:acknowledge, messages, subscription}, timeout)
+  end
+
   def init([project, options]) do
     connect(project, options)
   end

--- a/test/weddell/client/client_test.exs
+++ b/test/weddell/client/client_test.exs
@@ -16,7 +16,7 @@ defmodule Weddell.ClientTest do
     test "starts with a client by default" do
       nil = GenServer.whereis(Weddell.Client)
       Application.start(:weddell)
-      pid = GenServer.whereis(Weddell.Client)
+      pid = wait_for_server(Weddell.Client, 100)
       true = is_pid(pid)
       %Weddell.Client{} = Weddell.client()
     end
@@ -25,6 +25,9 @@ defmodule Weddell.ClientTest do
       Application.put_env(:weddell, :no_connect_on_start, true)
       nil = GenServer.whereis(Weddell.Client)
       Application.start(:weddell)
+      # assert_raise
+      nil = wait_for_server(Weddell.Client, 100)
+      assert {:noproc, _} = catch_exit(Weddell.client())
       nil = GenServer.whereis(Weddell.Client)
     end
 
@@ -41,4 +44,18 @@ defmodule Weddell.ClientTest do
       %Weddell.Client{} = GenServer.call(:my_client, {:client})
     end
   end
+
+  defp wait_for_server(server, 0) do
+    nil
+  end
+  defp wait_for_server(server, timeout) do
+    case GenServer.whereis(server) do
+      nil ->
+        :timer.sleep(10)
+        wait_for_server(server, timeout - 10)
+      pid ->
+        pid
+    end
+  end
+
 end

--- a/test/weddell/client/client_test.exs
+++ b/test/weddell/client/client_test.exs
@@ -1,2 +1,44 @@
 defmodule Weddell.ClientTest do
+  use ExUnit.Case
+
+  alias Weddell.{PublisherStubMock,
+                 SubscriberStubMock}
+
+  setup do
+    Application.stop(:weddell)
+    Application.put_env(:weddell, :publisher_stub, PublisherStubMock)
+    Application.put_env(:weddell, :subscriber_stub, SubscriberStubMock)
+    Application.put_env(:weddell, :project, "weddell")
+  end
+
+  describe "Weddel application" do
+
+    test "starts with a client by default" do
+      nil = GenServer.whereis(Weddell.Client)
+      Application.start(:weddell)
+      pid = GenServer.whereis(Weddell.Client)
+      true = is_pid(pid)
+      %Weddell.Client{} = Weddell.client()
+    end
+
+    test "starts without a client if :no_connect_on_start is set" do
+      Application.put_env(:weddell, :no_connect_on_start, true)
+      nil = GenServer.whereis(Weddell.Client)
+      Application.start(:weddell)
+      nil = GenServer.whereis(Weddell.Client)
+    end
+
+    test "client can be started separately" do
+      Application.put_env(:weddell, :no_connect_on_start, true)
+      nil = GenServer.whereis(Weddell.Client)
+      Application.start(:weddell)
+      {:ok, pid} = Weddell.Client.start_link(
+        "myproject",
+        Application.get_all_env(:weddell),
+        [name: :my_client])
+      true = is_pid(pid)
+
+      %Weddell.Client{} = GenServer.call(:my_client, {:client})
+    end
+  end
 end


### PR DESCRIPTION
Sometimes it's required to run multiple weddell clients and have a client in your own supervision tree.
By default the library starts a named client under the application supervision.

This PR allows to not start a default client and start clients separately. Also adds an API to communicate with clients by specifying the gen server reference.

Add an application option `:no_connect_on_start` to not start a default client.
Add `Weddell.Client.start_link/3` to start weddell clients separately
Add `Weddell.Client` apis to call weddell functions and make `Weddell` call them