### PR TITLE
Don't specify content_type header

### DIFF
--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -252,7 +252,7 @@ defmodule Weddell.Client do
   @doc false
   @spec request_opts() :: Keyword.t()
   def request_opts(extra_opts \\ []) do
-    [metadata: auth_header(), content_type: "application/grpc"]
+    [metadata: auth_header()]
     |> Enum.concat(extra_opts)
   end
 


### PR DESCRIPTION
It's not necessary, and it yields a warning message from the gRPC library:

```
:content_type has been deprecated, please use :codec
```

Removing it entirely doesn't change the request at all. The HTTP/2 header is implicitely `application/grpc`.