### PR TITLE
Add back content type header of application/grpc

### DIFF
--- a/lib/weddell/client.ex
+++ b/lib/weddell/client.ex
@@ -252,7 +252,7 @@ defmodule Weddell.Client do
   @doc false
   @spec request_opts() :: Keyword.t()
   def request_opts(extra_opts \\ []) do
-    [metadata: auth_header()]
+    [metadata: auth_header(), content_type: "application/grpc"]
     |> Enum.concat(extra_opts)
   end
 


### PR DESCRIPTION
The removal of this content type header appears to have cause a 404 error on publish: "status got is 404 instead of 200"